### PR TITLE
Resolving ColumnAnnotationRemoved correctly

### DIFF
--- a/EntityFrameworkCore.Extensions/Services/ExtendedMigrationSqlServerGenerator.cs
+++ b/EntityFrameworkCore.Extensions/Services/ExtendedMigrationSqlServerGenerator.cs
@@ -80,6 +80,6 @@ namespace EntityFrameworkCore.Extensions.Services
 
         private bool ColumnAnnotationAdded(string annotrationName, ColumnOperation oldColumn, ColumnOperation newColumn) => oldColumn.FindAnnotation(annotrationName) == null && newColumn.FindAnnotation(annotrationName) != null;
 
-        private bool ColumnAnnotationRemoved(string annotrationName, ColumnOperation oldColumn, ColumnOperation newColumn) => !ColumnAnnotationAdded(annotrationName, oldColumn, newColumn);
+        private bool ColumnAnnotationRemoved(string annotrationName, ColumnOperation oldColumn, ColumnOperation newColumn) => oldColumn.FindAnnotation(annotrationName) != null && newColumn.FindAnnotation(annotrationName) == null;
     }
 }


### PR DESCRIPTION
`ExtendedMigrationSqlServerGenerator.ColumnAnnotationRemoved` function used to return `true` for a situation where an annotation doesn't exist in neither the `oldColumn` or the `newColumn` which resulted in invalid migration generation.

For an altered column there was generated a SQL statement dropping an annotation that never existed which resulted in a non-runnable migration.